### PR TITLE
Ordered ID for the 3 minute Geek Show. 

### DIFF
--- a/app/Http/ArticleMapper.php
+++ b/app/Http/ArticleMapper.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jsugar
+ * Date: 03/02/2016
+ * Time: 22:47
+ */
+
+namespace app\Http;
+
+use Carbon\Carbon;
+use Vinelab\Rss\Article;
+
+class ArticleMapper
+{
+    /**
+     * @param Article $article
+     *
+     * @return array
+     * @internal param $Article
+     *
+     */
+    public static function map( Article $article )
+    {
+        return array(
+            'sortId'    => ( new Carbon( $article->pubDate ) )->format( 'YmdHis' ),
+            'title'       => $article->title,
+            'slug'        => str_slug( $article->title ),
+            'author'      => $article->author,
+            'description' => $article->description,
+            'link'        => $article->link,
+            'category'    => $article->category,
+            'pubDate'     => $article->pubDate,
+            'guid'        => $article->guid,
+            'enclosure'   => $article->enclosure,
+        );
+    }
+}

--- a/resources/views/episodes/index.blade.php
+++ b/resources/views/episodes/index.blade.php
@@ -7,12 +7,12 @@
     <div>
         <ul class="episodes-list">
             @foreach ($episodes as $key => $episode)
-            <li class="episode episode--in-list">
-                <div class="episode__date">{{ Carbon\Carbon::parse($episode->pubDate)->format('F j, Y H:i') }}</div>
-                <a href="/{{ $episodes->count() - $key }}">{{ $episode->title }}</a>
-                <p class="episode__description">{{ $episode->description }}</p>
-            </li>
-        @endforeach
+                <li class="episode episode--in-list">
+                    <div class="episode__date">{{ Carbon\Carbon::parse($episode['pubDate'])->format('F j, Y H:i') }}</div>
+                    <a href="/{{ $episode['sortId'] }}/{{ $episode['slug'] }}">{{ $episode['title'] }}</a>
+                    <p class="episode__description">{{ $episode['description'] }}</p>
+                </li>
+            @endforeach
         </ul>
     </div>
 

--- a/resources/views/episodes/show.blade.php
+++ b/resources/views/episodes/show.blade.php
@@ -2,14 +2,13 @@
 
 @section('content')
     <a href="/" class="back-to-index">&lt;- All episodes</a>
-        
     <div>
-        <h1>{{ $episode->title }}</h1>
-        <p>{{ $episode->description }}</p>
-        ({{ Carbon\Carbon::parse($episode->pubDate)->format('F j, Y H:i') }})
+        <h1>{{ $episode['title'] }}</h1>
+        <p>{{ $episode['description'] }}</p>
+        ({{ Carbon\Carbon::parse($episode['pubDate'])->format('F j, Y H:i') }})
         <br><br>
-        <audio controls preload="metadata" src="{{ $episode->guid }}">
-            <source src="{{ $episode->guid }}" type="audio/mpeg">
+        <audio controls preload="metadata" src="{{ $episode['guid'] }}">
+            <source src="{{ $episode['guid'] }}" type="audio/mpeg">
         </audio>
     </div>
 @endsection


### PR DESCRIPTION
This was a quick spike to see if I could create a usable ordered ID for the 3minutegeekshow.

The changes provide the following:
1. Introduce an article mapper to make handling of the article data easier since the rss library makes adding our own fields to it difficult.
2. construct an articleId from the rss pubDate that can be used as an incrementing/ordered id.
3. added a slug to the article object to make the urls prettier.

Some things I know are lacking:
1. There are no tests for the mapper.
2. The mapper is located in the wrong place.
3. Its debatable whether the slug should do in the data-mapper.
4. There is too much processing going on in the routes file.
