### PR TITLE
Configurable subscribe urls

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,5 +23,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="RSS_URL" value="https://www.briefs.fm/the-three-minute-geek-show.xml" />
     </php>
 </phpunit>

--- a/resources/views/customize/links.blade.php
+++ b/resources/views/customize/links.blade.php
@@ -1,9 +1,9 @@
     <p class="links">
         Subscribe: 
-        <a href="itpc://www.briefs.fm/the-three-minute-geek-show.xml">iTunes</a> |
-        <a href="overcast://x-callback-url/add?url=https://www.briefs.fm/the-three-minute-geek-show.xml">Overcast</a> |
-        <a href="podcast://www.briefs.fm/the-three-minute-geek-show.xml">Podcasts.app</a> | 
-        <a href="https://www.briefs.fm/the-three-minute-geek-show.xml">RSS</a> | 
-        <a href="http://briefs.fm/the-three-minute-geek-show">View in Briefs.fm</a>
+        <a href="itpc://{{ substr(env('RSS_URL'), 8) }}">iTunes</a> |
+        <a href="overcast://x-callback-url/add?url={{ env('RSS_URL') }}">Overcast</a> |
+        <a href="podcast://{{ substr(env('RSS_URL'), 8) }}">Podcasts.app</a> | 
+        <a href="{{ env('RSS_URL') }}">RSS</a> | 
+        <a href="http://{{ substr(env('RSS_URL'), 8, -4) }}">View in Briefs.fm</a>
     </p>
 

--- a/tests/features/ConfigurableSubscribeUrlsTest.php
+++ b/tests/features/ConfigurableSubscribeUrlsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ConfigurableSubscribeUrlsTest extends TestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function subscribe_urls_should_be_configurable()
+    {
+        $this->visit('/')
+             ->see('itpc://www.briefs.fm/the-three-minute-geek-show.xml')
+             ->see('overcast://x-callback-url/add?url=https://www.briefs.fm/the-three-minute-geek-show.xml')
+             ->see('podcast://www.briefs.fm/the-three-minute-geek-show.xml')
+             ->see('https://www.briefs.fm/the-three-minute-geek-show.xml')
+             ->see('http://briefs.fm/the-three-minute-geek-show');
+    }
+}


### PR DESCRIPTION
Hi Matt, I suggested this the other day on the twitch chat, but it got quickly drowned. I decided to go ahead and make a PR, because there is no better way for coders to explain code than using code.

The quick summary is that the subscribe links were hardcoded, and should come from the user configured value. It's a bit hacky, using substr(), but it works. It's gross and I would probably extract things to a class or a function, but I wanted the changes to be minimal.

It also would be easier if the .env value didn't include the protocol or the extension, but it's easier for the user to just copy and paste the whole thing, and that's more valuable.

Do whatever you will with this, and sorry for the lack of animated gif in the PR. Maybe I should have included a cat or something.
