### PR TITLE
Add Feed wrapper with incrementing IDs

### DIFF
--- a/app/Http/Controllers/EpisodeController.php
+++ b/app/Http/Controllers/EpisodeController.php
@@ -6,23 +6,21 @@ use Illuminate\Http\Request;
 
 use App\Http\Requests;
 use App\Http\Controllers\Controller;
+use App\RssFeed;
 use Carbon\Carbon;
-use Vinelab\Rss\Feed;
 
 class EpisodeController extends Controller
 {
-    public function index(Feed $feed)
+    public function index(RssFeed $feed)
     {
         return view('episodes.index')
             ->with('podcast', $feed->info())
-            ->with('episodes', $feed->articles);
+            ->with('episodes', $feed->articles->reverse());
     }
 
-    public function show($id, Feed $feed)
+    public function show($id, RssFeed $feed)
     {
-        $episode = $feed->articles->sortBy(function ($episode, $key) {
-            return new Carbon($episode->pubDate);
-        })->values()->get($id - 1);
+        $episode = $feed->articles->get($id);
 
         if ($episode == null) {
             abort(404);

--- a/app/Providers/RssServiceProvider.php
+++ b/app/Providers/RssServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\RssFeed;
 use Illuminate\Support\ServiceProvider;
 use Vinelab\Rss\Feed;
 use Vinelab\Rss\Rss;
@@ -19,6 +20,10 @@ class RssServiceProvider extends ServiceProvider
 //            return app('cache')->remember('feed', $minutes = 1, function () {
                 return (new Rss)->feed(config('customize.rss_url'));
 //            });
+        });
+
+        $this->app->singleton(RssFeed::class, function ($app) {
+            return RssFeed::rebuild((new Rss)->feed(config('customize.rss_url')));
         });
     }
 }

--- a/app/RssFeed.php
+++ b/app/RssFeed.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App;
+
+use Carbon\Carbon;
+use Vinelab\Rss\ArticlesCollection;
+use Vinelab\Rss\Feed;
+
+class RssFeed extends Feed
+{
+    public function __construct(Feed $feed)
+    {
+        $this->info = $feed->info();
+        $this->buildArticles($feed->articles);
+    }
+
+    /**
+     * Rebuild the Feed based on an already created Vinelab\Rss\Feed
+     */
+    public static function rebuild(Feed $feed)
+    {
+        return new static($feed);
+    }
+
+    /**
+     * Build the Articles with the IDs correctly set.
+     * The returned value is kept in Ascending Order.
+     */
+    public function buildArticles(ArticlesCollection $articles)
+    {
+        $this->articles = $articles
+        ->sortBy(function ($episode, $key) {
+            return new Carbon($episode->pubDate);
+        })
+        ->values()
+        ->each(function ($item, $key) {
+            $item->id = $key +1;
+        })
+        ->keyBy('id');
+    }
+}

--- a/resources/views/episodes/index.blade.php
+++ b/resources/views/episodes/index.blade.php
@@ -6,10 +6,10 @@
     <h2 class="episodes-title">Episodes</h2>
     <div>
         <ul class="episodes-list">
-            @foreach ($episodes as $key => $episode)
+            @foreach ($episodes as $episode)
             <li class="episode episode--in-list">
                 <div class="episode__date">{{ Carbon\Carbon::parse($episode->pubDate)->format('F j, Y H:i') }}</div>
-                <a href="/{{ $key }}">{{ $episode->title }}</a>
+                <a href="/{{ $episode->id }}">{{ $episode->title }}</a>
                 <p class="episode__description">{{ $episode->description }}</p>
 
                 @if (config('customize.disqus_shortname'))

--- a/resources/views/episodes/index.blade.php
+++ b/resources/views/episodes/index.blade.php
@@ -9,7 +9,7 @@
             @foreach ($episodes as $key => $episode)
             <li class="episode episode--in-list">
                 <div class="episode__date">{{ Carbon\Carbon::parse($episode->pubDate)->format('F j, Y H:i') }}</div>
-                <a href="/{{ $episodes->count() - $key }}">{{ $episode->title }}</a>
+                <a href="/{{ $key }}">{{ $episode->title }}</a>
                 <p class="episode__description">{{ $episode->description }}</p>
 
                 @if (config('customize.disqus_shortname'))


### PR DESCRIPTION
Hey Matt,

Just a simple wrapper class that implements incrementing IDs on the RSS Feed Articles.

I have added an RssFeed class which accepts a Vinelab\Rss\Feed instance and builds the Articles to have incrementing IDs. It still has to run `$key +1`, but it is managed within this class instead of the controller. From what I can see, everything else is accessible exactly as it was prior.

I did have to add the `->reverse()` call when displaying the articles on episodes.index. It might be best to store the Articles in ascending order for Collection simplicity, however, since this is a Podcast RSS in which the newest is usually accessed first, this could be sorted inversely in RssFeed if you think that's best.

This will only work if the RSS feed is always a **complete** list of the articles available.
