### PR TITLE
Adds redirect to index page with sweetalert when episode is not found

### DIFF
--- a/app/Http/Controllers/EpisodeController.php
+++ b/app/Http/Controllers/EpisodeController.php
@@ -25,9 +25,12 @@ class EpisodeController extends Controller
         })->values()->get($id - 1);
 
         if ($episode == null) {
-            abort(404);
+            return redirect('/')->with('flash_message', [
+                'title' => 'Episode Not Found',
+                'body' => 'Please select from the list below'
+            ]);
         }
-        
+
         return view('episodes.show')
             ->with('podcast', $feed->info())
             ->with('pageTitle', $episode->title)

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -1,4 +1,6 @@
 <?php
 
-Route::get('/', 'EpisodeController@index');
-Route::get('{id}', 'EpisodeController@show');
+Route::group(['middleware' => 'web'], function() {
+	Route::get('/', 'EpisodeController@index');
+	Route::get('{id}', 'EpisodeController@show');
+});

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::group(['middleware' => 'web'], function() {
-	Route::get('/', 'EpisodeController@index');
-	Route::get('{id}', 'EpisodeController@show');
+Route::group(['middleware' => 'web'], function () {
+    Route::get('/', 'EpisodeController@index');
+    Route::get('{id}', 'EpisodeController@show');
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,12 @@ var elixir = require('laravel-elixir');
  */
 
 elixir(function(mix) {
+	mix.copy('node_modules/sweetalert/dist/sweetalert.css', 'resources/assets/sass/sweetalert.scss');
+
     mix.sass('app.scss')
         .version('css/app.css');
+
+    mix.scripts([
+    	'../../../node_modules/sweetalert/dist/sweetalert.min.js'
+    ], 'public/js/app.js');
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "gulp": "^3.8.8"
   },
   "dependencies": {
+    "bootstrap-sass": "^3.0.0",
     "laravel-elixir": "^4.0.0",
-    "bootstrap-sass": "^3.0.0"
+    "sweetalert": "^1.1.3"
   }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,3 +1,5 @@
+@import "sweetalert.scss";
+
 /* apply a natural box layout model to all elements, but allowing components to change */
 html {
     box-sizing: border-box;
@@ -87,7 +89,7 @@ body {
         border: 1px solid rgba(0, 0, 0, 0.1);
         padding: 1em;
         margin-bottom: 1em;
-        
+
         .episode__description {
             font-size: 0.8em;
             margin-top: 0;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -33,7 +33,7 @@
     <body>
         <div class="content">
             @include('partials.header', ['podcast' => $podcast])
-            
+
             @yield('content')
 
             <p class="footer">
@@ -53,5 +53,17 @@
         @endif
 
         @yield('scripts')
+
+        @if (session('flash_message'))
+            <script src="js/app.js"></script>
+            <script>
+                swal({
+                    title: "{{ session('flash_message.title') }}",
+                    text: "{{ session('flash_message.body') }}",
+                    timer: 1700,
+                    showConfirmButton: false
+                });
+            </script>
+        @endif
     </body>
 </html>


### PR DESCRIPTION
Hey Matt, Would you be interested in redirecting to the index page is an episode is not found? i.e. threeminutegeekshow.com/0 or /asdf etc. 

I added SweetAlert to send a flash message that says the episode was not found...

Not sure your plan for the styles this could be swapped for a bootstrap alert or something else. 

Here is what it looks like: 
![redirectsweetalert](https://cloud.githubusercontent.com/assets/1762128/13032989/cf779ab2-d2bb-11e5-9f00-f455fb5ce4f8.gif)

If you like the idea, let me know your thoughts on how I'm importing the css/js and if you prefer a different approach.

Thanks. 
--Jeff
